### PR TITLE
Fix for lodash, and request for more data to be passed to getPartName()

### DIFF
--- a/ChunkSplittingPlugin.js
+++ b/ChunkSplittingPlugin.js
@@ -118,13 +118,13 @@ function extractOriginsOfChunkWithExtractedModules(chunk, reason = 'async common
 // from CommonsChunkPlugin (async methods):
 function extractOriginsOfChunksWithExtractedModules(chunks, reason) {
   return flatMap(
-    chunks,
+    Array.from(chunks),
     chunk => extractOriginsOfChunkWithExtractedModules(chunk, reason)
   )
 }
 
 function breakChunksIntoPieces(chunksToSplit, compilation, {
-  getPartName = (sourceChunk, idx) => sourceChunk.name && `${sourceChunk.name}-part-${leadingZeros(idx + 1, 2)}`,
+  getPartName = (sourceChunk, idx, extractableModules) => sourceChunk.name && `${sourceChunk.name}-part-${leadingZeros(idx + 1, 2)}`,
   maxModulesPerChunk = 100,
   maxModulesPerEntry = 1,
   segregator = 
@@ -161,7 +161,7 @@ function breakChunksIntoPieces(chunksToSplit, compilation, {
 
     // return new chunks
     return freshChunkModuleGroups.map((extractableModules, idx) => {
-      let targetName = getPartName(chunk, idx)
+      let targetName = getPartName(chunk, idx, extractableModules)
       const targetChunk = compilation.addChunk(targetName)
 
       // Remove modules that are moved to commons chunk from their original chunks


### PR DESCRIPTION
- Fix so flatMap from lodash will process chunks and call extractOriginsOfChunkWithExtractedModules(). (lodash is expecting an Array, but a Set is passed to it, so the iterator is never used and the "async split..." string is not added to the chunk origins as expected.

- Pass set of modules to getPartName() to provide additional data for those who need it.

Thanks for this plugin, it's working great!
