### PR TITLE
Allow Node v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chunk-splitting-plugin",
   "engines": {
-    "node": ">=7"
+    "node": ">=6"
   },
   "files": [
     "ChunkSplittingPlugin.js"


### PR DESCRIPTION
This package cannot be installed with Yarn in Node v6. We are still using Node v6 because we are integrating with Google Cloud function emulator that requires Node v6.

I don't see any reason this module will not work in Node 6.